### PR TITLE
Use a default thumbnail when album is empty

### DIFF
--- a/client/app/models/album.coffee
+++ b/client/app/models/album.coffee
@@ -48,7 +48,12 @@ module.exports = class Album extends Backbone.Model
 
     # Build cover thumb src from coverPicture field.
     getThumbSrc: ->
-        "photos/thumbs/#{@get 'coverPicture'}.jpg" + app.urlKey
+        coverPicture = @get 'coverPicture'
+        if coverPicture?
+            thumbSrc = "photos/thumbs/#{@get 'coverPicture'}.jpg"
+        else
+            thumbSrc = "img/nophotos.gif"
+        return thumbSrc + app.urlKey
 
     getPublicURL: (key) ->
         urlKey = if key then "?key=#{key}" else ""


### PR DESCRIPTION
I created a new album but didn't upload any photo yet, so there's no thumbnail, and in album list the album is invisible (I have to hover the tile to see it).
Disclaimer: I didn't test this quick patch, the main `Cakefile` miss a `build` task to build the whole project :S 
