### PR TITLE
Two bugfixes

### DIFF
--- a/client/app/router.coffee
+++ b/client/app/router.coffee
@@ -76,6 +76,7 @@ module.exports = class Router extends Backbone.Router
             @cancelNavigate = false
         else
 
+            # default window title
             document.title = t 'application title'
 
             if @mainView and @mainView.dirty

--- a/client/app/views/album.coffee
+++ b/client/app/views/album.coffee
@@ -74,6 +74,7 @@ module.exports = class AlbumView extends BaseView
         @galery.album = @model
         @galery.render()
 
+        # Use title of album as window title
         document.title = "#{t 'application title'} - #{@model.get 'title'}"
 
         if @options.editable

--- a/client/app/views/albumslist_item.coffee
+++ b/client/app/views/albumslist_item.coffee
@@ -22,6 +22,7 @@ module.exports = class AlbumItem extends BaseView
         @image = @$ 'img'
         @image.attr 'src', @model.getThumbSrc()
         helpers.rotate @model.attributes.orientation, @image
+        # remove loading background one image is loaded
         if @image.get(0).complete
             @onImageLoaded()
         else

--- a/client/app/views/galery.coffee
+++ b/client/app/views/galery.coffee
@@ -123,6 +123,12 @@ module.exports = class Galery extends ViewCollection
         parts = url.split('/')
         id = parts[parts.length - 1]
         id = id.split('.')[0]
+        # if collection has not been saved, we must search by url
+        if not @collection.get(id)?
+            photo = @collection.find (e) ->
+                return e.attributes.src.split('/').pop().split('.')[0] is id
+            if photo?
+                id = photo.cid
         return id
 
     # Rotate 90° left the picture by updating css and orientation.

--- a/client/app/views/galery.coffee
+++ b/client/app/views/galery.coffee
@@ -87,7 +87,9 @@ module.exports = class Galery extends ViewCollection
         'drop'     : 'onFilesDropped'
         'dragover' : 'onDragOver'
         'dragleave' : 'onDragLeave'
-        'change #uploader': 'onFilesChanged'
+        # change isn't fired on first click ???
+        #'change #uploader': 'onFilesChanged'
+        'click #uploader': 'onFilesClick'
         'click #browse-files': 'displayBrowser'
 
     # event listeners for D&D events
@@ -167,10 +169,13 @@ module.exports = class Galery extends ViewCollection
 
     onFilesChanged: (evt) =>
         @handleFiles @uploader[0].files
-        # reset the iNput
+        # reset the input
         old = @uploader
         @uploader = old.clone true
         old.replaceWith @uploader
+
+    onFilesClick: (evt) ->
+        document.getElementById('uploader').addEventListener 'change', @onFilesChanged
 
     beforeImageDisplayed: (link) =>
         id = @getIdPhoto link.href

--- a/client/app/views/photo.coffee
+++ b/client/app/views/photo.coffee
@@ -31,6 +31,7 @@ module.exports = class PhotoView extends BaseView
         @progressbar = @$ '.progressfill'
         helpers.rotate @model.get('orientation'), @image
         @link.addClass 'server' unless @model.isNew()
+        # remove loading background one image is loaded
         if @image.get(0).complete
             @onImageLoaded()
         else


### PR DESCRIPTION
- selecting files for upload immediately after opening an album failed randomly (jQuery didn't see the first 'change' event on input field, don't know why);
- allow to rotate photo immediately after they have been updated.
