### PR TITLE
Fix access rights on temporary upload folder

### DIFF
--- a/server/config.coffee
+++ b/server/config.coffee
@@ -58,9 +58,17 @@ module.exports =
             localizationManager.setRenderer viewEngine
 
             # create the uploads folder
-            try fs.mkdirSync path.join os.tmpdir(), 'uploads'
+            uploadFolder = path.join os.tmpdir(), 'uploads'
+            try fs.mkdirSync uploadFolder
             catch err then if err.code isnt 'EEXIST'
                 console.log "Something went wrong while creating uploads folder"
+                console.log err
+            # Ensure other apps can't read into this folder
+            try fs.chmodSync uploadFolder, '0700'
+            catch err
+                console.log """
+                Something went wrong while setting rights on upload folder
+                """
                 console.log err
 
             # Initialize realtime


### PR DESCRIPTION
For now, the temporary folder used to upload photos is readable by anybody, so other applications can read its content. Sometime, the pictures in it are not deleted after being processed, so a malicious application could access to private photos.
