### PR TITLE
Add lazy loading to albums

### DIFF
--- a/client/app/templates/photo.jade
+++ b/client/app/templates/photo.jade
@@ -1,5 +1,5 @@
 a(href="#{src}", title="#{title}")
-  img(src="#{thumbsrc}", alt="#{title}")
+  img(data-src="#{thumbsrc}", alt="#{title}")
   div.progressfill
 
 button.delete.flatbtn

--- a/client/app/views/photo.coffee
+++ b/client/app/views/photo.coffee
@@ -31,13 +31,23 @@ module.exports = class PhotoView extends BaseView
         @progressbar = @$ '.progressfill'
         helpers.rotate @model.get('orientation'), @image
         @link.addClass 'server' unless @model.isNew()
-        # remove loading background one image is loaded
+
+        # Images are not loaded by default, they are only loaded when the
+        # user reaches them by scrolling the window.
+        @image.unveil()
+
         if @image.get(0).complete
             @onImageLoaded()
         else
             @image.on 'load', =>
                 @onImageLoaded()
 
+    # Force display of current image by setting its source attribute.
+    setSource: ->
+        source = @$("img").attr "data-src"
+        @$("img").attr "src", source
+
+    # Change progress bar state to show the progress of the upload.
     setProgress: (percent) ->
         @progressbar.css 'width', percent + '%'
 

--- a/client/vendor/scripts/jquery.unveil.js
+++ b/client/vendor/scripts/jquery.unveil.js
@@ -1,0 +1,56 @@
+/**
+ * jQuery Unveil
+ * A very lightweight jQuery plugin to lazy load images
+ * http://luis-almeida.github.com/unveil
+ *
+ * Licensed under the MIT license.
+ * Copyright 2013 Luís Almeida
+ * https://github.com/luis-almeida
+ */
+
+;(function($) {
+
+  $.fn.unveil = function(threshold, callback) {
+
+    var $w = $(window),
+        th = threshold || 0,
+        retina = window.devicePixelRatio > 1,
+        attrib = retina? "data-src-retina" : "data-src",
+        images = this,
+        loaded;
+
+    this.one("unveil", function() {
+      var source = this.getAttribute(attrib);
+      source = source || this.getAttribute("data-src");
+      if (source) {
+        this.setAttribute("src", source);
+        if (typeof callback === "function") callback.call(this);
+      }
+    });
+
+    function unveil() {
+      var inview = images.filter(function() {
+        var $e = $(this);
+        if ($e.is(":hidden")) return;
+
+        var wt = $w.scrollTop(),
+            wb = wt + $w.height(),
+            et = $e.offset().top,
+            eb = et + $e.height();
+
+        return eb >= wt - th && et <= wb + th;
+      });
+
+      loaded = inview.trigger("unveil");
+      images = images.not(loaded);
+    }
+
+    $w.on("scroll.unveil resize.unveil lookup.unveil", unveil);
+
+    unveil();
+
+    return this;
+
+  };
+
+})(window.jQuery || window.Zepto);


### PR DESCRIPTION
Via this PR, albums don't load all their thumbnail pictures anymore. It loads the 50 first pictures then it relies on a lazy loading library (unveil) to load the pictures that appear on the screen.

I had to remove an option from photobox that displayed all the thumbnails when browsing pictures. It is less fun but it will avoid unexpected behavior.
