### PR TITLE
Extract date from exif if available

### DIFF
--- a/build/server/helpers/thumb.js
+++ b/build/server/helpers/thumb.js
@@ -35,7 +35,7 @@ module.exports = thumb = {
     return gm(filePath).options({
       imageMagick: true
     }).identify(function(err, data) {
-      var GPS, alt, lat, long, metadata, orientation;
+      var GPS, alt, lat, long, metadata, orientation, ref1, ref2, ref3;
       if (err) {
         return callback(err);
       } else {
@@ -59,7 +59,7 @@ module.exports = thumb = {
         metadata = {
           exif: {
             orientation: orientation,
-            date: data.Properties['date:create'],
+            date: (ref1 = (ref2 = (ref3 = data.Properties['exif:DateTimeOriginal']) != null ? ref3 : data.Properties['exif:DateTimeDigitized']) != null ? ref2 : data.Properties['exif:DateTime']) != null ? ref1 : data.Properties['date:create'],
             gps: GPS
           }
         };

--- a/server/helpers/thumb.coffee
+++ b/server/helpers/thumb.coffee
@@ -61,7 +61,14 @@ module.exports = thumb =
                 metadata =
                     exif:
                         orientation:    orientation
-                        date:           data.Properties['date:create']
+                        # From Exif 2.2 specs :
+                        # DateTimeOriginal - Date of the original creation of data
+                        # DateTimeDigitized - Date of the digitization of data
+                        # DateTime - Modification date of the file
+                        # In case of a raw photo 3 should be the same
+                        # In case of a retouched photo DateTimeOriginal should be the date of the shot, DateTime the retouching date.
+                        # Fallback to creation date if  no exif.
+                        date:           data.Properties['exif:DateTimeOriginal'] ? data.Properties['exif:DateTimeDigitized'] ? data.Properties['exif:DateTime'] ? data.Properties['date:create']
                         gps:            GPS
 
                 callback null, metadata


### PR DESCRIPTION
I'm continuing my simple debugging tweaks...
As of today, photos' date is the uploaded file creation date, which is of little use. 
This PR extract date from exifs, and fallback as follow if values are not set :
- Original creation date,
- Digitized creation date,
- Modification date
- Uploaded file creation date.

Is there a way to fire a script right after an app update ? This would be useful if we want to sort already uploaded photos, as there is quite some Cozy instances with no dates on photos in the wild.
